### PR TITLE
Change buy token for ink to UDST0

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -145,7 +145,7 @@ sites:
         "kind": "sell",
         "sellAmountBeforeFee": "10000000000000000000",
         "sellToken": "0x4200000000000000000000000000000000000006",
-        "buyToken": "0x2D270e6886d130D724215A266106e6832161EAEd",
+        "buyToken": "0x0200C29006150606B650577BBE7B6248F58470c1",
         "from": "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
       }
 

--- a/history/bff-slippage-tolerance-arbitrum-one.yml
+++ b/history/bff-slippage-tolerance-arbitrum-one.yml
@@ -1,7 +1,7 @@
 url: https://bff.cow.fi/42161/markets/0xcb8b5cd20bdcaea9a010ac1f8d835824f5c87a04-0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/slippageTolerance
 status: up
 code: 200
-responseTime: 430
-lastUpdated: 2026-03-19T23:07:55.097Z
+responseTime: 5
+lastUpdated: 2026-03-20T11:32:20.535Z
 startTime: 2024-08-14T14:19:56.114Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/bff-slippage-tolerance-avalanche.yml
+++ b/history/bff-slippage-tolerance-avalanche.yml
@@ -1,7 +1,7 @@
 url: https://bff.cow.fi/43114/markets/0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7-0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7/slippageTolerance
 status: up
 code: 200
-responseTime: 596
-lastUpdated: 2026-03-19T23:08:01.001Z
+responseTime: 7
+lastUpdated: 2026-03-20T11:32:25.373Z
 startTime: 2025-06-20T14:21:21.215Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/bff-slippage-tolerance-base.yml
+++ b/history/bff-slippage-tolerance-base.yml
@@ -1,7 +1,7 @@
 url: https://bff.cow.fi/8453/markets/0xc694a91e6b071bF030A18BD3053A7fE09B6DaE69-0x4200000000000000000000000000000000000006/slippageTolerance
 status: up
 code: 200
-responseTime: 461
-lastUpdated: 2026-03-19T23:07:57.999Z
+responseTime: 6
+lastUpdated: 2026-03-20T11:32:22.968Z
 startTime: 2025-06-20T14:21:20.199Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/bff-slippage-tolerance-gnosis-chain.yml
+++ b/history/bff-slippage-tolerance-gnosis-chain.yml
@@ -1,7 +1,7 @@
 url: https://bff.cow.fi/100/markets/0x177127622c4a00f3d409b75571e12cb3c8973d3c-0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d/slippageTolerance
 status: up
 code: 200
-responseTime: 348
-lastUpdated: 2026-03-19T23:07:52.257Z
+responseTime: 8
+lastUpdated: 2026-03-20T11:32:18.100Z
 startTime: 2024-08-14T14:19:55.542Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/bff-slippage-tolerance-mainnet.yml
+++ b/history/bff-slippage-tolerance-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://bff.cow.fi/1/markets/0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB-0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/slippageTolerance
 status: up
 code: 200
-responseTime: 459
-lastUpdated: 2026-03-19T23:07:49.490Z
+responseTime: 90
+lastUpdated: 2026-03-20T11:32:15.655Z
 startTime: 2024-08-14T14:19:54.904Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/bff-slippage-tolerance-polygon.yml
+++ b/history/bff-slippage-tolerance-polygon.yml
@@ -1,7 +1,7 @@
 url: https://bff.cow.fi/137/markets/0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063-0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270/slippageTolerance
 status: up
 code: 200
-responseTime: 21
-lastUpdated: 2026-03-19T23:08:03.396Z
+responseTime: 10
+lastUpdated: 2026-03-20T11:32:27.804Z
 startTime: 2025-06-20T14:21:22.090Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/bff-usd-price-arbitrum-one.yml
+++ b/history/bff-usd-price-arbitrum-one.yml
@@ -1,7 +1,7 @@
 url: https://bff.cow.fi/42161/tokens/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1/usdPrice
 status: up
 code: 200
-responseTime: 21
-lastUpdated: 2026-03-19T23:08:10.982Z
+responseTime: 14
+lastUpdated: 2026-03-20T11:32:35.095Z
 startTime: 2024-08-14T14:20:01.197Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/bff-usd-price-avalanche.yml
+++ b/history/bff-usd-price-avalanche.yml
@@ -1,7 +1,7 @@
 url: https://bff.cow.fi/43114/tokens/0xb31f66aa3c1e785363f0875a1b74e27b85fd66c7/usdPrice
 status: up
 code: 200
-responseTime: 21
-lastUpdated: 2026-03-19T23:08:15.851Z
+responseTime: 19
+lastUpdated: 2026-03-20T11:32:40.004Z
 startTime: 2025-06-20T14:21:24.339Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/bff-usd-price-base.yml
+++ b/history/bff-usd-price-base.yml
@@ -1,7 +1,7 @@
 url: https://bff.cow.fi/8453/tokens/0x4200000000000000000000000000000000000006/usdPrice
 status: up
 code: 200
-responseTime: 18
-lastUpdated: 2026-03-19T23:08:13.426Z
+responseTime: 14
+lastUpdated: 2026-03-20T11:32:37.572Z
 startTime: 2025-06-20T14:21:23.917Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/bff-usd-price-gnosis-chain.yml
+++ b/history/bff-usd-price-gnosis-chain.yml
@@ -1,7 +1,7 @@
 url: https://bff.cow.fi/100/tokens/0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d/usdPrice
 status: up
 code: 200
-responseTime: 13
-lastUpdated: 2026-03-19T23:08:08.537Z
+responseTime: 16
+lastUpdated: 2026-03-20T11:32:32.678Z
 startTime: 2024-08-14T14:19:57.431Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/bff-usd-price-mainnet.yml
+++ b/history/bff-usd-price-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://bff.cow.fi/1/tokens/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2/usdPrice
 status: up
 code: 200
-responseTime: 20
-lastUpdated: 2026-03-19T23:08:05.837Z
+responseTime: 17
+lastUpdated: 2026-03-20T11:32:30.242Z
 startTime: 2024-08-14T14:19:56.642Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/bff-usd-price-polygon.yml
+++ b/history/bff-usd-price-polygon.yml
@@ -1,7 +1,7 @@
 url: https://bff.cow.fi/137/tokens/0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270/usdPrice
 status: up
 code: 200
-responseTime: 25
-lastUpdated: 2026-03-19T23:08:18.273Z
+responseTime: 14
+lastUpdated: 2026-03-20T11:32:42.421Z
 startTime: 2025-06-20T14:21:24.762Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/co-w-protocol-docs.yml
+++ b/history/co-w-protocol-docs.yml
@@ -1,7 +1,7 @@
 url: https://docs.cow.fi
 status: up
 code: 200
-responseTime: 94
-lastUpdated: 2026-03-19T23:07:04.330Z
+responseTime: 104
+lastUpdated: 2026-03-20T11:31:31.420Z
 startTime: 2022-04-03T21:35:45.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/co-w-protocol-learn.yml
+++ b/history/co-w-protocol-learn.yml
@@ -1,7 +1,7 @@
 url: https://learn.cow.fi
 status: up
 code: 200
-responseTime: 199
-lastUpdated: 2026-03-19T23:07:06.988Z
+responseTime: 145
+lastUpdated: 2026-03-20T11:31:34.042Z
 startTime: 2024-01-10T22:13:31.530Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/co-w-protocol.yml
+++ b/history/co-w-protocol.yml
@@ -1,7 +1,7 @@
 url: https://cow.fi
 status: up
 code: 200
-responseTime: 225
-lastUpdated: 2026-03-19T23:07:01.843Z
+responseTime: 217
+lastUpdated: 2026-03-20T11:31:28.855Z
 startTime: 2022-04-03T21:35:44.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/co-w-swap-barn.yml
+++ b/history/co-w-swap-barn.yml
@@ -1,7 +1,7 @@
 url: https://barn.cow.fi/
 status: up
 code: 200
-responseTime: 88
-lastUpdated: 2026-03-19T23:06:54.179Z
+responseTime: 95
+lastUpdated: 2026-03-20T11:31:21.015Z
 startTime: 2023-03-22T16:17:33.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/co-w-swap-token-list.yml
+++ b/history/co-w-swap-token-list.yml
@@ -1,7 +1,7 @@
 url: https://files.cow.fi/tokens/CowSwap.json
 status: up
 code: 200
-responseTime: 84
-lastUpdated: 2026-03-19T23:07:12.198Z
+responseTime: 98
+lastUpdated: 2026-03-20T11:31:39.296Z
 startTime: 2023-03-22T16:17:35.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/co-w-swap-widget.yml
+++ b/history/co-w-swap-widget.yml
@@ -1,7 +1,7 @@
 url: https://widget.cow.fi
 status: up
 code: 200
-responseTime: 103
-lastUpdated: 2026-03-19T23:06:56.715Z
+responseTime: 80
+lastUpdated: 2026-03-20T11:31:23.600Z
 startTime: 2024-01-18T11:25:24.975Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/co-w-swap.yml
+++ b/history/co-w-swap.yml
@@ -1,7 +1,7 @@
 url: https://swap.cow.fi/
 status: up
 code: 200
-responseTime: 91
-lastUpdated: 2026-03-19T23:06:49.133Z
+responseTime: 94
+lastUpdated: 2026-03-20T11:31:15.947Z
 startTime: 2023-03-22T16:17:32.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/explorer-barn.yml
+++ b/history/explorer-barn.yml
@@ -1,7 +1,7 @@
 url: https://barn.explorer.cow.fi
 status: up
 code: 200
-responseTime: 87
-lastUpdated: 2026-03-19T23:06:59.210Z
+responseTime: 108
+lastUpdated: 2026-03-20T11:31:26.152Z
 startTime: 2022-04-03T21:35:43.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/explorer.yml
+++ b/history/explorer.yml
@@ -1,7 +1,7 @@
 url: http://explorer.cow.fi
 status: up
 code: 200
-responseTime: 155
-lastUpdated: 2026-03-19T23:06:51.714Z
+responseTime: 124
+lastUpdated: 2026-03-20T11:31:18.506Z
 startTime: 2022-04-03T21:35:41.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/mev-blocker.yml
+++ b/history/mev-blocker.yml
@@ -1,7 +1,7 @@
 url: https://mevblocker.io/
 status: up
 code: 200
-responseTime: 289
-lastUpdated: 2026-03-19T23:07:09.708Z
+responseTime: 243
+lastUpdated: 2026-03-20T11:31:36.732Z
 startTime: 2023-03-22T15:52:08.000Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/quote-api-arbitrum-one.yml
+++ b/history/quote-api-arbitrum-one.yml
@@ -1,7 +1,7 @@
 url: https://api.cow.fi/arbitrum_one/api/v1/quote
 status: up
 code: 200
-responseTime: 2901
-lastUpdated: 2026-03-19T23:07:24.673Z
+responseTime: 1818
+lastUpdated: 2026-03-20T11:31:51.202Z
 startTime: 2024-07-16T14:00:04.319Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/quote-api-avalanche.yml
+++ b/history/quote-api-avalanche.yml
@@ -1,7 +1,7 @@
 url: https://api.cow.fi/avalanche/api/v1/quote
 status: up
 code: 200
-responseTime: 2038
-lastUpdated: 2026-03-19T23:07:32.475Z
+responseTime: 1920
+lastUpdated: 2026-03-20T11:31:59.889Z
 startTime: 2025-06-20T14:21:13.993Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/quote-api-base.yml
+++ b/history/quote-api-base.yml
@@ -1,7 +1,7 @@
 url: https://api.cow.fi/base/api/v1/quote
 status: up
 code: 200
-responseTime: 913
-lastUpdated: 2026-03-19T23:07:27.974Z
+responseTime: 1916
+lastUpdated: 2026-03-20T11:31:55.544Z
 startTime: 2025-06-20T14:21:11.900Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/quote-api-bnb.yml
+++ b/history/quote-api-bnb.yml
@@ -1,7 +1,7 @@
 url: https://api.cow.fi/bnb/api/v1/quote
 status: up
 code: 200
-responseTime: 1229
-lastUpdated: 2026-03-19T23:07:41.081Z
+responseTime: 426
+lastUpdated: 2026-03-20T11:32:07.368Z
 startTime: 2025-09-10T11:02:20.947Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/quote-api-gnosis-chain.yml
+++ b/history/quote-api-gnosis-chain.yml
@@ -1,7 +1,7 @@
 url: https://api.cow.fi/xdai/api/v1/quote
 status: up
 code: 200
-responseTime: 197
-lastUpdated: 2026-03-19T23:07:19.378Z
+responseTime: 240
+lastUpdated: 2026-03-20T11:31:46.937Z
 startTime: 2024-07-16T14:00:02.720Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/quote-api-ink.yml
+++ b/history/quote-api-ink.yml
@@ -1,7 +1,7 @@
 url: https://api.cow.fi/ink/api/v1/quote
 status: up
 code: 200
-responseTime: 605
-lastUpdated: 2026-03-20T11:15:55.599Z
+responseTime: 674
+lastUpdated: 2026-03-20T11:32:13.155Z
 startTime: 2026-02-20T11:38:43.327Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/quote-api-linea.yml
+++ b/history/quote-api-linea.yml
@@ -1,7 +1,7 @@
 url: https://api.cow.fi/linea/api/v1/quote
 status: up
 code: 200
-responseTime: 275
-lastUpdated: 2026-03-19T23:07:43.766Z
+responseTime: 286
+lastUpdated: 2026-03-20T11:32:10.081Z
 startTime: 2025-11-27T10:05:33.839Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/quote-api-mainnet.yml
+++ b/history/quote-api-mainnet.yml
@@ -1,7 +1,7 @@
 url: https://api.cow.fi/mainnet/api/v1/quote
 status: up
 code: 200
-responseTime: 2096
-lastUpdated: 2026-03-19T23:07:16.799Z
+responseTime: 2435
+lastUpdated: 2026-03-20T11:31:44.227Z
 startTime: 2024-07-16T13:59:57.782Z
 generator: Upptime <https://github.com/upptime/upptime>

--- a/history/quote-api-polygon.yml
+++ b/history/quote-api-polygon.yml
@@ -1,7 +1,7 @@
 url: https://api.cow.fi/polygon/api/v1/quote
 status: up
 code: 200
-responseTime: 2414
-lastUpdated: 2026-03-19T23:07:37.304Z
+responseTime: 2256
+lastUpdated: 2026-03-20T11:32:04.552Z
 startTime: 2025-06-20T14:21:15.264Z
 generator: Upptime <https://github.com/upptime/upptime>


### PR DESCRIPTION
USDC has a low success rate, and low solver support.
So changing the uptime bot token to USDT0, which has better liquidity on Ink.