### PR TITLE
chore: fix setup workflow

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -40,19 +40,19 @@ jobs:
         with:
           command: "update-template"
         env:
-          GH_PAT: ${{ github.token }}
+          GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update response time
         uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
         with:
           command: "response-time"
         env:
-          GH_PAT: ${{ github.token }}
+          GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Update summary in README
         uses: upptime/uptime-monitor@e620a0d7a97526a295bbe3970495bff6495bdf27 # v1.41.0
         with:
           command: "readme"
         env:
-          GH_PAT: ${{ github.token }}
+          GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - name: Generate graphs
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1
         with:
@@ -63,7 +63,7 @@ jobs:
         with:
           command: "site"
         env:
-          GH_PAT: ${{ github.token }}
+          GH_PAT: ${{ secrets.GH_PAT || github.token }}
       - uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
         name: GitHub Pages Deploy
         with:


### PR DESCRIPTION
Use `secrets.GH_PAT || github.token` in Setup CI so Upptime can push workflow updates with a token that has workflow permission. 

Attempt to fix https://github.com/cowprotocol/uptime/actions/runs/24458049399/job/71464110255

> Removed legacy .github/workflows
Added new .github/workflows
Removed template files
Removed old data from api
Removed old data from graphs
Removed old data from history
[master ea1b878] :arrow_up: Update @upptime to v1.41.0
 8 files changed, 46 insertions(+), 60 deletions(-)
To https://github.com/cowprotocol/uptime
 ! [remote rejected] master -> master (refusing to allow a GitHub App to create or update workflow `.github/workflows/graphs.yml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/cowprotocol/uptime'
All done!