### PR TITLE
fix: pin upptime/updates action to full-length commit SHA

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -32,6 +32,6 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_PAT || github.token }}
       - name: Update code
-        uses: upptime/updates@master
+        uses: upptime/updates@c8be3a2281e37dfb3211b7cd8f847b014e551634 # master
         env:
           GH_PAT: ${{ secrets.GH_PAT || github.token }}


### PR DESCRIPTION
## Summary

- Pins `upptime/updates@master` to its full-length commit SHA (`c8be3a2281e37dfb3211b7cd8f847b014e551634`) to comply with the org-level policy "Require actions to be pinned to a full-length commit SHA"

## Context

The `Updates CI` workflow was failing because `upptime/updates@master` uses a branch reference instead of a pinned SHA. All other workflows in this repo already use pinned SHAs.

Failed run: https://github.com/cowprotocol/uptime/actions/runs/25650246396/job/75286945525

Made with [Cursor](https://cursor.com)